### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/crime-2-withUI/report/routes.py
+++ b/crime-2-withUI/report/routes.py
@@ -5,6 +5,7 @@ import imghdr
 from email.message import EmailMessage
 from PIL import Image
 from flask import render_template, url_for, flash, redirect, request ,abort
+from urllib.parse import urlparse
 from report import app, db, bcrypt 
 from report.forms import *
 from report.models import User, Report 
@@ -56,7 +57,11 @@ def login():
             if current_user.id == 1:
                 return redirect(url_for('admin'))
             next_page = request.args.get('next')
-            return redirect(next_page) if next_page else redirect(url_for('home'))
+            if next_page:
+                parsed_url = urlparse(next_page)
+                if not parsed_url.netloc and not parsed_url.scheme:
+                    return redirect(next_page)
+            return redirect(url_for('home'))
         else:
             flash('Login Unsuccessful. Please check email and password', 'danger')
     return render_template('login.html', title='Login', form=form)


### PR DESCRIPTION
Potential fix for [https://github.com/PANDATD/crime-reporting-system/security/code-scanning/2](https://github.com/PANDATD/crime-reporting-system/security/code-scanning/2)

To fix the issue, we need to validate the `next_page` parameter before using it in the `redirect` function. A common approach is to ensure that the `next_page` value is a relative URL (i.e., it does not include a host or scheme). This can be achieved using the `urlparse` function from Python's `urllib.parse` module. If the `next_page` value is not a relative URL, the application should redirect to a safe default location, such as the home page.

Steps to implement the fix:
1. Import the `urlparse` function from `urllib.parse`.
2. Parse the `next_page` value and check that it does not include a `netloc` or `scheme`.
3. If the `next_page` value is invalid, redirect to the home page instead.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
